### PR TITLE
Add form screens using REST

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,0 +1,29 @@
+from django import forms
+from alunos.models import Aluno
+from exercicios.models import Exercicio
+from treinos.models import Rotina
+from avaliacao.models import Avaliacao
+
+
+class AlunoForm(forms.ModelForm):
+    class Meta:
+        model = Aluno
+        fields = '__all__'
+
+
+class ExercicioForm(forms.ModelForm):
+    class Meta:
+        model = Exercicio
+        fields = '__all__'
+
+
+class RotinaForm(forms.ModelForm):
+    class Meta:
+        model = Rotina
+        exclude = ['exercicios', 'criado_em']
+
+
+class AvaliacaoForm(forms.ModelForm):
+    class Meta:
+        model = Avaliacao
+        fields = '__all__'

--- a/core/templates/core/aluno_form.html
+++ b/core/templates/core/aluno_form.html
@@ -1,0 +1,26 @@
+{% extends 'core/base.html' %}
+{% block title %}Novo Aluno{% endblock %}
+{% block content %}
+<h1>Novo Aluno</h1>
+<form id="aluno-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Salvar</button>
+    <a href="{% url 'alunos_list' %}" class="btn btn-secondary">Cancelar</a>
+</form>
+<script>
+const form = document.getElementById('aluno-form');
+form.addEventListener('submit', function(e){
+    e.preventDefault();
+    const data = new FormData(form);
+    fetch('/api/alunos/', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': data.get('csrfmiddlewaretoken') },
+        body: data
+    }).then(r => {
+        if(r.ok){ window.location.href = '{% url 'alunos_list' %}'; }
+        else { r.json().then(d => alert(JSON.stringify(d))); }
+    });
+});
+</script>
+{% endblock %}

--- a/core/templates/core/alunos_list.html
+++ b/core/templates/core/alunos_list.html
@@ -7,7 +7,7 @@
     <div class="col-12">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1>Alunos</h1>
-            <a href="#" class="btn btn-primary">Novo Aluno</a>
+            <a href="{% url 'aluno_create' %}" class="btn btn-primary">Novo Aluno</a>
         </div>
     </div>
 </div>

--- a/core/templates/core/avaliacao_form.html
+++ b/core/templates/core/avaliacao_form.html
@@ -1,0 +1,26 @@
+{% extends 'core/base.html' %}
+{% block title %}Nova Avaliação{% endblock %}
+{% block content %}
+<h1>Nova Avaliação</h1>
+<form id="avaliacao-form" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Salvar</button>
+    <a href="{% url 'avaliacoes_list' %}" class="btn btn-secondary">Cancelar</a>
+</form>
+<script>
+const form = document.getElementById('avaliacao-form');
+form.addEventListener('submit', function(e){
+    e.preventDefault();
+    const data = new FormData(form);
+    fetch('/api/avaliacoes/', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': data.get('csrfmiddlewaretoken') },
+        body: data
+    }).then(r => {
+        if(r.ok){ window.location.href = '{% url 'avaliacoes_list' %}'; }
+        else { r.json().then(d => alert(JSON.stringify(d))); }
+    });
+});
+</script>
+{% endblock %}

--- a/core/templates/core/avaliacoes_list.html
+++ b/core/templates/core/avaliacoes_list.html
@@ -7,7 +7,7 @@
     <div class="col-12">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1>Avaliações</h1>
-            <a href="#" class="btn btn-primary">Nova Avaliação</a>
+            <a href="{% url 'avaliacao_create' %}" class="btn btn-primary">Nova Avaliação</a>
         </div>
     </div>
 </div>

--- a/core/templates/core/exercicio_form.html
+++ b/core/templates/core/exercicio_form.html
@@ -1,0 +1,26 @@
+{% extends 'core/base.html' %}
+{% block title %}Novo Exercício{% endblock %}
+{% block content %}
+<h1>Novo Exercício</h1>
+<form id="exercicio-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Salvar</button>
+    <a href="{% url 'exercicios_list' %}" class="btn btn-secondary">Cancelar</a>
+</form>
+<script>
+const form = document.getElementById('exercicio-form');
+form.addEventListener('submit', function(e){
+    e.preventDefault();
+    const data = new FormData(form);
+    fetch('/api/exercicios/', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': data.get('csrfmiddlewaretoken') },
+        body: data
+    }).then(r => {
+        if(r.ok){ window.location.href = '{% url 'exercicios_list' %}'; }
+        else { r.json().then(d => alert(JSON.stringify(d))); }
+    });
+});
+</script>
+{% endblock %}

--- a/core/templates/core/exercicios_list.html
+++ b/core/templates/core/exercicios_list.html
@@ -7,7 +7,7 @@
     <div class="col-12">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1>Exercícios</h1>
-            <a href="#" class="btn btn-primary">Novo Exercício</a>
+            <a href="{% url 'exercicio_create' %}" class="btn btn-primary">Novo Exercício</a>
         </div>
     </div>
 </div>

--- a/core/templates/core/treino_form.html
+++ b/core/templates/core/treino_form.html
@@ -1,0 +1,26 @@
+{% extends 'core/base.html' %}
+{% block title %}Novo Treino{% endblock %}
+{% block content %}
+<h1>Novo Treino</h1>
+<form id="treino-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Salvar</button>
+    <a href="{% url 'treinos_list' %}" class="btn btn-secondary">Cancelar</a>
+</form>
+<script>
+const form = document.getElementById('treino-form');
+form.addEventListener('submit', function(e){
+    e.preventDefault();
+    const data = new FormData(form);
+    fetch('/api/treinos/', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': data.get('csrfmiddlewaretoken') },
+        body: data
+    }).then(r => {
+        if(r.ok){ window.location.href = '{% url 'treinos_list' %}'; }
+        else { r.json().then(d => alert(JSON.stringify(d))); }
+    });
+});
+</script>
+{% endblock %}

--- a/core/templates/core/treinos_list.html
+++ b/core/templates/core/treinos_list.html
@@ -7,7 +7,7 @@
     <div class="col-12">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1>Treinos</h1>
-            <a href="#" class="btn btn-primary">Novo Treino</a>
+            <a href="{% url 'treino_create' %}" class="btn btn-primary">Novo Treino</a>
         </div>
     </div>
 </div>

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,11 +1,24 @@
 from django.urls import path
-from .views import homepage, alunos_list, exercicios_list, treinos_list, avaliacoes_list
+from .views import (
+    homepage,
+    alunos_list,
+    exercicios_list,
+    treinos_list,
+    avaliacoes_list,
+    aluno_create,
+    exercicio_create,
+    treino_create,
+    avaliacao_create,
+)
 
 urlpatterns = [
-    path('', homepage, name='homepage'),  # Rota para a homepage
-    path('alunos/', alunos_list, name='alunos_list'),  # Rota para listagem de alunos
-    path('exercicios/', exercicios_list, name='exercicios_list'),  # Rota para listagem de exercícios
-    path('treinos/', treinos_list, name='treinos_list'),  # Rota para listagem de treinos
-    path('avaliacoes/', avaliacoes_list, name='avaliacoes_list'),  # Rota para listagem de avaliações
-
+    path('', homepage, name='homepage'),
+    path('alunos/', alunos_list, name='alunos_list'),
+    path('alunos/novo/', aluno_create, name='aluno_create'),
+    path('exercicios/', exercicios_list, name='exercicios_list'),
+    path('exercicios/novo/', exercicio_create, name='exercicio_create'),
+    path('treinos/', treinos_list, name='treinos_list'),
+    path('treinos/novo/', treino_create, name='treino_create'),
+    path('avaliacoes/', avaliacoes_list, name='avaliacoes_list'),
+    path('avaliacoes/novo/', avaliacao_create, name='avaliacao_create'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -87,3 +87,25 @@ def avaliacoes_list(request):
         'is_paginated': avaliacoes.has_other_pages(),
         'page_obj': avaliacoes,
     })
+from .forms import AlunoForm, ExercicioForm, RotinaForm, AvaliacaoForm
+
+
+def aluno_create(request):
+    form = AlunoForm()
+    return render(request, 'core/aluno_form.html', {'form': form})
+
+
+def exercicio_create(request):
+    form = ExercicioForm()
+    return render(request, 'core/exercicio_form.html', {'form': form})
+
+
+def treino_create(request):
+    form = RotinaForm()
+    return render(request, 'core/treino_form.html', {'form': form})
+
+
+def avaliacao_create(request):
+    form = AvaliacaoForm()
+    return render(request, 'core/avaliacao_form.html', {'form': form})
+


### PR DESCRIPTION
## Summary
- create `ModelForm` helpers
- show create pages for each model
- wire up new URLs and update template links
- post form data to REST API via fetch

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687430eb96e8832d97bec03c5f40dea8