### PR TITLE
Remove stale comment

### DIFF
--- a/Pages/views/treino_views.py
+++ b/Pages/views/treino_views.py
@@ -365,7 +365,6 @@ def treino_exercicios(request, treino_id):
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=500)
 
-# Criar treino a partir de um template
 @csrf_exempt
 @require_http_methods(["POST"])
 def criar_treino_de_template(request):


### PR DESCRIPTION
## Summary
- remove obsolete comment from treino views

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687494bbf6f4832dab99e78d0e6cffc2