### PR TITLE
Fix exercise form group selection and cleanup

### DIFF
--- a/Pages/templates/paginas/treinos.html
+++ b/Pages/templates/paginas/treinos.html
@@ -72,71 +72,7 @@
       </div>
     </div>
 
-    <!-- Card Treinos - dinâmico -->
-     <!-- TODO listagem de treino gravados no banco -->
-      <!-- TODO modal cadastro de treino-predefinido-->
-    <div class="col-md-6">
-      <div class="card shadow rounded-4">
-        <div class="card-header bg-white d-flex justify-content-between align-items-center">
-          <h5 class="mb-0 fw-semibold">Gerenciar Treinos</h5>
-          <button class="btn btn-primary d-flex align-items-center gap-2 rounded-pill" data-bs-toggle="modal" data-bs-target="#treinoModal">
-            <i class="bi bi-plus-circle"></i> Cadastrar Treino
-          </button>
-        </div>
-        <div class="card-body">
-          <form class="mb-3 d-flex gap-2">
-            <input type="text" name="busca_treino" class="form-control rounded-pill" placeholder="Pesquisar treino...">
-            <button class="btn btn-outline-secondary rounded-circle" type="submit">
-              <i class="bi bi-search"></i>
-            </button>
-          </form>
-          <ul class="list-group list-group-flush">
-            {% for treino in treinos_page %}
-            <li class="list-group-item d-flex justify-content-between align-items-center bg-light rounded-3 my-2 shadow-sm">
-              <div>
-                <div class="fw-semibold">{{ treino.nome }}</div>
-                <div class="text-muted small">{{ treino.anotacoes }}</div>
-              </div>
-              <div class="d-flex gap-2">
-                <button class="btn btn-outline-primary btn-sm rounded-circle" title="Editar">
-                  <i class="bi bi-pencil"></i>
-                </button>
-                <button class="btn btn-outline-danger btn-sm rounded-circle" title="Remover">
-                  <i class="bi bi-trash"></i>
-                </button>
-              </div>
-            </li>
-            {% empty %}
-            <li class="list-group-item">Nenhum treino cadastrado.</li>
-            {% endfor %}
-          </ul>
-<nav aria-label="Paginação Treinos">
-  <ul class="pagination justify-content-center mt-3">
-    {% if treinos_page.has_previous %}
-      <li class="page-item">
-        <a class="page-link" href="?page_treino={{ treinos_page.previous_page_number }}{% if busca_treino %}&busca_treino={{ busca_treino }}{% endif %}">Anterior</a>
-      </li>
-    {% else %}
-      <li class="page-item disabled"><span class="page-link">Anterior</span></li>
-    {% endif %}
-    {% for num in treinos_page.paginator.page_range %}
-      {% if treinos_page.number == num %}
-        <li class="page-item active"><span class="page-link">{{ num }}</span></li>
-      {% else %}
-        <li class="page-item"><a class="page-link" href="?page_treino={{ num }}{% if busca_treino %}&busca_treino={{ busca_treino }}{% endif %}">{{ num }}</a></li>
-      {% endif %}
-    {% endfor %}
-    {% if treinos_page.has_next %}
-      <li class="page-item"><a class="page-link" href="?page_treino={{ treinos_page.next_page_number }}{% if busca_treino %}&busca_treino={{ busca_treino }}{% endif %}">Próximo</a></li>
-    {% else %}
-      <li class="page-item disabled"><span class="page-link">Próximo</span></li>
-    {% endif %}
-  </ul>
-</nav>
 
-        </div>
-      </div>
-    </div>
 
   </div>
 </div>

--- a/Pages/views/treino_views.py
+++ b/Pages/views/treino_views.py
@@ -76,8 +76,14 @@ def cadastrar_exercicio(request):
     if request.method == 'POST':
         nome = request.POST.get('nome', '').strip()
         descricao = request.POST.get('descricao', '').strip()
-        grupo_muscular_id = request.POST.get('grupo_muscular', '').strip()
-        secundario_id = request.POST.get('grupo_muscular_secundario', '').strip()
+
+        # Permite selecionar até dois grupos musculares na tela de cadastro
+        grupos_selecionados = request.POST.getlist('grupo_muscular')
+        grupo_muscular_id = grupos_selecionados[0].strip() if grupos_selecionados else ''
+        if len(grupos_selecionados) > 1:
+            secundario_id = grupos_selecionados[1].strip()
+        else:
+            secundario_id = request.POST.get('grupo_muscular_secundario', '').strip()
 
         if not nome or not grupo_muscular_id:
             messages.error(request, "Preencha todos os campos obrigatórios.")


### PR DESCRIPTION
## Summary
- allow up to two muscle groups when saving an exercise
- remove "Gerenciar Treinos" card from training page

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6874971a4240832da1b7e9dbb35fd6fc